### PR TITLE
Release v2.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to the "php-docblocker" extension will be documented in this file.
 
 ## [Unreleased]
+
+## [2.3.10] - 2021-09-05
 - Add should to list of bool return type functions - Thanks @ImClarky
 - Fix issue where functions named with a bool return prefix were incorrectly given bool return type - Thanks @ImClarky
 - Fix issue with snake case class names in PHP7 return types - Thanks @rmccue
@@ -167,7 +169,8 @@ All notable changes to the "php-docblocker" extension will be documented in this
 ## 0.1.0 - 2017-03-12
 - Initial release
 
-[Unreleased]: https://github.com/neild3r/vscode-php-docblocker/compare/v2.3.9...HEAD
+[Unreleased]: https://github.com/neild3r/vscode-php-docblocker/compare/v2.3.10...HEAD
+[2.3.10]: https://github.com/neild3r/vscode-php-docblocker/compare/v2.3.9...v2.3.10
 [2.3.9]: https://github.com/neild3r/vscode-php-docblocker/compare/v2.3.8...v2.3.9
 [2.3.8]: https://github.com/neild3r/vscode-php-docblocker/compare/v2.3.7...v2.3.8
 [2.3.7]: https://github.com/neild3r/vscode-php-docblocker/compare/v2.3.6...v2.3.7

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "php-docblocker-test",
-  "version": "2.3.9",
+  "version": "2.3.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "php-docblocker-test",
   "displayName": "PHP DocBlocker",
   "description": "A simple, dependency free PHP specific DocBlocking package",
-  "version": "2.3.9",
+  "version": "2.3.10",
   "license": "MIT",
   "publisher": "neilbrayfield",
   "author": "Neil Brayfield <dev@brayfield.uk>",


### PR DESCRIPTION
- Add should to list of bool return type functions - Thanks @ImClarky
- Fix issue where functions named with a bool return prefix were incorrectly given bool return type - Thanks @ImClarky
- Fix issue with snake case class names in PHP7 return types - Thanks @rmccue