### PR TITLE
v2.3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to the "php-docblocker" extension will be documented in this file.
 
 ## [Unreleased]
+
+## [2.3.11] - 2021-09-07
 - Add should to list of bool return type functions - Thanks @ImClarky
 - Fix issue where functions named with a bool return prefix were incorrectly given bool return type - Thanks @ImClarky
 - Fix issue with snake case class names in PHP7 return types - Thanks @rmccue
@@ -172,7 +174,8 @@ All notable changes to the "php-docblocker" extension will be documented in this
 ## 0.1.0 - 2017-03-12
 - Initial release
 
-[Unreleased]: https://github.com/neild3r/vscode-php-docblocker/compare/v2.3.10...HEAD
+[Unreleased]: https://github.com/neild3r/vscode-php-docblocker/compare/v2.3.11...HEAD
+[2.3.11]: https://github.com/neild3r/vscode-php-docblocker/compare/v2.3.10...v2.3.11
 [2.3.10]: https://github.com/neild3r/vscode-php-docblocker/compare/v2.3.9...v2.3.10
 [2.3.9]: https://github.com/neild3r/vscode-php-docblocker/compare/v2.3.8...v2.3.9
 [2.3.8]: https://github.com/neild3r/vscode-php-docblocker/compare/v2.3.7...v2.3.8

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "php-docblocker-test",
-  "version": "2.3.10",
+  "version": "2.3.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "php-docblocker-test",
   "displayName": "PHP DocBlocker",
   "description": "A simple, dependency free PHP specific DocBlocking package",
-  "version": "2.3.10",
+  "version": "2.3.11",
   "license": "MIT",
   "publisher": "neilbrayfield",
   "author": "Neil Brayfield <dev@brayfield.uk>",


### PR DESCRIPTION
- Add should to list of bool return type functions - Thanks @ImClarky
- Fix issue where functions named with a bool return prefix were incorrectly given bool return type - Thanks @ImClarky
- Fix issue with snake case class names in PHP7 return types - Thanks @rmccue